### PR TITLE
🛠️FIX: fixes both state reference and invalid css link errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import { Fade, Slide } from 'react-awesome-reveal'
 export default function App() {
 
   const [userEmail, setUserEmail] = useState("")
-  const [isSectionVisible, setIsSectionVisible] = useState(!isSectionVisible)
+  const [isSectionVisible, setIsSectionVisible] = useState(false)
 
   const toggleSectionVisibility = () => {
     setIsSectionVisible(!isSectionVisible)

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@10..48,200;10..48,500;10..48,800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200;12..96,500;12..96,600;12..96,800&display=swap');
 
 *{
   padding:0; margin:0; top:0; right:0; bottom:0; left:0;


### PR DESCRIPTION
I made this change because there was a reference error, because I was using a value that wasn't created yet. So I had to change it to `false` instead of `!isSectionVisible`